### PR TITLE
chore: update axios baseURL

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 # .env
-REACT_APP_API_URL=http://localhost:5000
+# REACT_APP_API_URL=http://localhost:5000
+VITE_BACKEND_URL=http://localhost:8000

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: `${process.env.REACT_APP_BACKEND_URL}/api`,
+  baseURL: `${import.meta.env.VITE_BACKEND_URL}/api`,
   headers: {
     "Content-Type": "application/json",
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   server:{
     proxy:{
       '/api':{
-        target: 'http://localhost:5000',
+        target: 'http://localhost:8000',
         changeOrigin: true,
 
       }


### PR DESCRIPTION
- Vite 기반 React 프로젝트에서 process.env 안 써서 baseURL을 import.meta.env 를 쓰고, 노출하려는 변수는 VITE_ 가 꼭 필요.
- 효안이 로컬 5000번 안돼서 8000번으로 바꿨어용
- https://chatgpt.com/s/t_68a3f2215e70819187e647c61a365130  (챗지피티 답변) 
